### PR TITLE
Add support for #[bindcode(with="...")] to enum variants

### DIFF
--- a/derive/src/attribute.rs
+++ b/derive/src/attribute.rs
@@ -178,6 +178,44 @@ impl FromAttribute for FieldAttributes {
     }
 }
 
+#[derive(Default)]
+pub struct VariantAttributes {
+    pub with: String,
+}
+
+impl FromAttribute for VariantAttributes {
+    fn parse(group: &Group) -> Result<Option<Self>> {
+        let attributes = match parse_tagged_attribute(group, "bincode")? {
+            Some(body) => body,
+            None => return Ok(None),
+        };
+        let mut result = Self::default();
+        for attribute in attributes {
+            match attribute {
+                ParsedAttribute::Property(key, val) if key.to_string() == "with" => {
+                    let val_string = val.to_string();
+                    if val_string.starts_with('"') && val_string.ends_with('"') {
+                        result.with = val_string[1..val_string.len() - 1].to_string();
+                        if result.with.is_empty() {
+                            return Err(Error::custom_at("Should not be empty", val.span()));
+                        }
+                    } else {
+                        return Err(Error::custom_at("Should be a literal str", val.span()));
+                    }
+                }
+                ParsedAttribute::Property(i, _) | ParsedAttribute::Tag(i) => {
+                    return Err(Error::custom_at("Unknown field attribute", i.span()))
+                }
+                _ => {}
+            }
+        }
+        if result.with.is_empty() {
+            return Err(Error::custom_at("Missing `with` field", group.span()));
+        }
+        Ok(Some(result))
+    }
+}
+
 fn mutually_exclusive_err(ident: &Ident, other: &str) -> Error {
     Error::custom_at(
         format!("Attribute {ident} is mutually exclusive with {other}"),

--- a/derive/src/derive_enum.rs
+++ b/derive/src/derive_enum.rs
@@ -1,4 +1,4 @@
-use crate::attribute::{ContainerAttributes, FieldAttributes};
+use crate::attribute::{ContainerAttributes, FieldAttributes, VariantAttributes};
 use virtue::{parse::IdentOrIndex, prelude::*};
 
 const TUPLE_FIELD_PREFIX: &str = "field_";
@@ -146,6 +146,16 @@ impl DeriveEnum {
                             })?;
                             body.punct('?');
                             body.punct(';');
+                            // Dispatch to a custom encoder if supplied
+                            // We pass all the destructured fields
+                            if let Some(VariantAttributes{with}) = variant.attributes.get_attribute::<VariantAttributes>()? {
+                                let fields = variant_fields.iter().flat_map(|f| f.infos.iter().map(|i| match &i.name {
+                                    IdentOrIndex::Ident { ident, .. } => ident.to_string(),
+                                    IdentOrIndex::Index { index, .. } => format!("{TUPLE_FIELD_PREFIX}{index}"),
+                                })).collect::<Vec<_>>().join(", ");
+                                body.push_parsed(format!("{with}::encode({fields}, encoder)"))?;
+                                return Ok(());
+                            }
                             // If we have any fields, encode them all one by one
                             if let Some(variant_fields) = &variant_fields {
                                 for field_info in &variant_fields.infos {
@@ -325,6 +335,11 @@ impl DeriveEnum {
                                 variant_case.push(variant_index.remove(0));
                             }
                             variant_case.puncts("=>");
+                            // Dispatch to a custom decoder if supplied
+                            if let Some(VariantAttributes{with}) = variant.attributes.get_attribute::<VariantAttributes>()? {
+                                variant_case.push_parsed(format!("{}::decode(decoder),", with))?;
+                                continue;
+                            }
                             variant_case.push_parsed("core::result::Result::Ok")?;
                             variant_case.group(Delimiter::Parenthesis, |variant_case_body| {
                                 // Self::Variant { }
@@ -451,6 +466,11 @@ impl DeriveEnum {
                                 variant_case.push(variant_index.remove(0));
                             }
                             variant_case.puncts("=>");
+                            // Dispatch to a custom decoder if supplied
+                            if let Some(VariantAttributes{with}) = variant.attributes.get_attribute::<VariantAttributes>()? {
+                                variant_case.push_parsed(format!("{}::borrow_decode(decoder),", with))?;
+                                continue;
+                            }
                             variant_case.push_parsed("core::result::Result::Ok")?;
                             variant_case.group(Delimiter::Parenthesis, |variant_case_body| {
                                 // Self::Variant { }

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -151,6 +151,32 @@ fn test_decode_tuple() {
     assert_eq!(len, 6);
 }
 
+mod encode_enum_variant {
+    use crate::TestEnum;
+
+    pub fn encode<E: bincode::enc::Encoder>(
+        f1: &u32,
+        f2: &u32,
+        encoder: &mut E,
+    ) -> Result<(), bincode::error::EncodeError> {
+        bincode::Encode::encode(f2, encoder)?;
+        bincode::Encode::encode(f1, encoder)
+    }
+    pub fn decode<Context, D: bincode::de::Decoder<Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<TestEnum, bincode::error::DecodeError> {
+        let f2 = <u32 as bincode::Decode<Context>>::decode(decoder)?;
+        let f1 = <u32 as bincode::Decode<Context>>::decode(decoder)?;
+
+        Ok(TestEnum::Quux { a: f1, b: f2 })
+    }
+    pub fn borrow_decode<'de, Context, D: bincode::de::BorrowDecoder<'de, Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<TestEnum, bincode::error::DecodeError> {
+        decode(decoder)
+    }
+}
+
 #[derive(bincode::Encode, bincode::Decode, PartialEq, Debug, Eq)]
 pub enum TestEnum {
     Foo,
@@ -164,6 +190,13 @@ pub enum TestEnum {
         #[bincode(skip)] Option<u64>,
         #[bincode(with = "encode_as_double")] u8,
     ),
+    #[bincode(with = "encode_enum_variant")]
+    Qux(u32, u32),
+    #[bincode(with = "encode_enum_variant")]
+    Quux {
+        a: u32,
+        b: u32,
+    },
 }
 #[test]
 fn test_encode_enum_struct_variant() {
@@ -183,6 +216,26 @@ fn test_decode_enum_struct_variant() {
         bincode::decode_from_slice(&slice, bincode::config::standard()).unwrap();
     assert_eq!(result, start);
     assert_eq!(len, 2);
+}
+
+#[test]
+fn test_encode_enum_struct_variant_custom() {
+    let start = TestEnum::Quux { a: 1, b: 2 };
+    let mut slice = [0u8; 1024];
+    let bytes_written =
+        bincode::encode_into_slice(start, &mut slice, bincode::config::standard()).unwrap();
+    assert_eq!(bytes_written, 3);
+    // The encoder switches the order of the fields
+    assert_eq!(&slice[..bytes_written], &[4, 2, 1]);
+}
+#[test]
+fn test_denode_enum_struct_variant_custom() {
+    let start = TestEnum::Quux { a: 1, b: 2 };
+    let slice = [4, 2, 1];
+    let (result, len): (TestEnum, usize) =
+        bincode::decode_from_slice(&slice, bincode::config::standard()).unwrap();
+    assert_eq!(result, start);
+    assert_eq!(len, 3);
 }
 
 #[test]
@@ -223,6 +276,27 @@ fn test_decode_enum_tuple_variant() {
         bincode::decode_from_slice(&slice, bincode::config::standard()).unwrap();
     assert_eq!(result, start);
     assert_eq!(len, 7);
+}
+
+#[test]
+fn test_encode_enum_tuple_variant_custom() {
+    let start = TestEnum::Qux(1, 2);
+    let mut slice = [0u8; 1024];
+    let bytes_written =
+        bincode::encode_into_slice(start, &mut slice, bincode::config::standard()).unwrap();
+    assert_eq!(bytes_written, 3);
+    // The encoder switches the order of the fields
+    assert_eq!(&slice[..bytes_written], &[3, 2, 1]);
+}
+#[test]
+fn test_denode_enum_tuple_variant_custom() {
+    let start = TestEnum::Quux { a: 1, b: 2 };
+    // N.B. even though we set the discriminant to 3 it still returns `Quux` which is 4 because that is what the decoder always does
+    let slice = [3, 2, 1];
+    let (result, len): (TestEnum, usize) =
+        bincode::decode_from_slice(&slice, bincode::config::standard()).unwrap();
+    assert_eq!(result, start);
+    assert_eq!(len, 3);
 }
 
 #[derive(bincode::Encode, bincode::BorrowDecode, PartialEq, Debug, Eq)]


### PR DESCRIPTION
This allows you to customize encoding/decoding for a single enum variant which is useful for large enums
